### PR TITLE
promote(skill): cloudflare-zerotrust-ops v0.1.0

### DIFF
--- a/workspaces/_template/skills/cloudflare-zerotrust-ops/SKILL.md
+++ b/workspaces/_template/skills/cloudflare-zerotrust-ops/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cloudflare-zerotrust-ops
+description: Read-first Cloudflare Zero Trust operations from an API token credential. Use when validating token access, listing accounts/zones, and inspecting tunnels safely.
+---
+
+# Cloudflare Zero Trust Ops
+
+Use this skill for controlled Cloudflare operations with minimum privilege.
+
+## Preconditions
+
+- Store the API token as an agent credential. In this agent the current credential name is `cloudflare`; `cloudflare_api_token` is also acceptable if you later rename it.
+- Never print or expose token values.
+- Prefer read/check first, then propose write changes.
+- This workspace runtime may not have `curl`, so the bundled scripts use `python3` standard library HTTP calls.
+- Before sending Cloudflare operational data to external systems such as Notion, get explicit user confirmation.
+
+## Supported actions
+
+Current bundled scripts are read-oriented:
+- verify token validity
+- list accessible accounts and zones
+- list tunnels for a known account
+
+Write actions for DNS/WAF/Zero Trust are intentionally out of scope until explicitly implemented and approved.
+
+## Workflow
+
+1. Fetch the stored credential from the agent. Current default: `cloudflare`.
+
+2. Verify token:
+```bash
+CLOUDFLARE_API_TOKEN=... bash skills/cloudflare-zerotrust-ops/scripts/verify_token.sh
+```
+This confirms token authentication state. It does not guarantee authorization to every Cloudflare endpoint.
+
+3. Discover accounts/zones:
+```bash
+CLOUDFLARE_API_TOKEN=... bash skills/cloudflare-zerotrust-ops/scripts/list_accounts_zones.sh
+```
+
+4. Inspect tunnels (if account_id known):
+```bash
+CLOUDFLARE_API_TOKEN=... bash skills/cloudflare-zerotrust-ops/scripts/list_tunnels.sh <account_id>
+```
+
+5. For future write actions, require explicit confirmation with impact + rollback.
+
+## Safety rules
+
+- Do not perform destructive changes without explicit user approval.
+- Log only IDs, names and statuses; never secrets.
+- Do not send Cloudflare operational data to third-party services unless the user explicitly asks for it.
+- Do not export the token globally in a long-lived shell session.
+- Do not use shell tracing such as `set -x` while passing secrets.
+
+## Safe execution note
+
+The shell scripts expect `CLOUDFLARE_API_TOKEN` in the process environment. On this platform, stored credentials are visible to the root agent but not always injected into shell/tool runtimes automatically. Safe pattern:
+
+- fetch the stored credential in the root agent
+- if using this agent as configured today, read credential `cloudflare`
+- pass it to the script only for that single process invocation
+- never write it to workspace files
+- never echo the token value in output

--- a/workspaces/_template/skills/cloudflare-zerotrust-ops/manifest.json
+++ b/workspaces/_template/skills/cloudflare-zerotrust-ops/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "cloudflare-zerotrust-ops",
+  "description": "Read-first Cloudflare Zero Trust operations using a stored API token credential. Use it to validate token access, list accounts/zones, and inspect tunnels safely.",
+  "version": "0.1.0"
+}

--- a/workspaces/_template/skills/cloudflare-zerotrust-ops/scripts/list_accounts_zones.sh
+++ b/workspaces/_template/skills/cloudflare-zerotrust-ops/scripts/list_accounts_zones.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "CLOUDFLARE_API_TOKEN missing in environment" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+import json, os, urllib.request
+headers={'Authorization': 'Bearer ' + os.environ['CLOUDFLARE_API_TOKEN']}
+def get(url):
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode())
+acc = get('https://api.cloudflare.com/client/v4/accounts')
+zon = get('https://api.cloudflare.com/client/v4/zones')
+out = {
+  'accounts': [{'id': x.get('id'), 'name': x.get('name')} for x in acc.get('result', [])],
+  'zones': [
+    {
+      'id': x.get('id'), 'name': x.get('name'), 'status': x.get('status'), 'type': x.get('type'),
+      'account_id': (x.get('account') or {}).get('id'),
+      'account_name': (x.get('account') or {}).get('name')
+    }
+    for x in zon.get('result', [])
+  ]
+}
+print(json.dumps(out, ensure_ascii=False, indent=2))
+PY

--- a/workspaces/_template/skills/cloudflare-zerotrust-ops/scripts/list_tunnels.sh
+++ b/workspaces/_template/skills/cloudflare-zerotrust-ops/scripts/list_tunnels.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <account_id>" >&2
+  exit 2
+fi
+ACCOUNT_ID="$1"
+
+if [[ ! "$ACCOUNT_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "Invalid account_id format" >&2
+  exit 2
+fi
+
+if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "CLOUDFLARE_API_TOKEN missing in environment" >&2
+  exit 1
+fi
+
+ACCOUNT_ID="$ACCOUNT_ID" python3 - <<'PY'
+import json, os, urllib.request, urllib.parse
+account_id = os.environ['ACCOUNT_ID']
+req = urllib.request.Request(
+    f'https://api.cloudflare.com/client/v4/accounts/{urllib.parse.quote(account_id)}/cfd_tunnel',
+    headers={'Authorization': 'Bearer ' + os.environ['CLOUDFLARE_API_TOKEN']}
+)
+with urllib.request.urlopen(req, timeout=30) as r:
+    j = json.loads(r.read().decode())
+out = {
+  'success': j.get('success'),
+  'result': [
+    {'id': x.get('id'), 'name': x.get('name'), 'status': x.get('status'), 'created_at': x.get('created_at')}
+    for x in j.get('result', [])
+  ],
+  'errors': j.get('errors', [])
+}
+print(json.dumps(out, ensure_ascii=False, indent=2))
+PY

--- a/workspaces/_template/skills/cloudflare-zerotrust-ops/scripts/verify_token.sh
+++ b/workspaces/_template/skills/cloudflare-zerotrust-ops/scripts/verify_token.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "CLOUDFLARE_API_TOKEN missing in environment" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+import json, os, urllib.request, urllib.error
+req = urllib.request.Request(
+    'https://api.cloudflare.com/client/v4/user/tokens/verify',
+    headers={'Authorization': 'Bearer ' + os.environ['CLOUDFLARE_API_TOKEN']}
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as r:
+        j = json.loads(r.read().decode())
+except urllib.error.HTTPError as e:
+    body = e.read().decode(errors='replace')
+    print(json.dumps({'success': False, 'http_status': e.code, 'error_body': body}, ensure_ascii=False, indent=2))
+    raise SystemExit(1)
+out = {
+    'success': j.get('success'),
+    'result': j.get('result'),
+    'errors': j.get('errors', []),
+    'messages': j.get('messages', []),
+    'note': 'Token verification confirms authentication state, not full authorization to every accounts/zones/tunnels endpoint.'
+}
+print(json.dumps(out, ensure_ascii=False, indent=2))
+PY


### PR DESCRIPTION
## Promoción: skill/cloudflare-zerotrust-ops v0.1.0

**Origen:** catálogo global
**Patches aplicados:** 0 (último: N/A)
**Validación de código:** OK

### Descripción
Read-first Cloudflare Zero Trust operations using a stored API token credential. Use it to validate token access, list accounts/zones, and inspect tunnels safely.

### Dependencias Python
_Ninguna detectada._

### Escaneo de seguridad
✅ Sin problemas detectados.

### Cambios en `_template/`
Sin cambios respecto a la versión actual en `_template/`.

### Cómo testear
1. Crear un agente nuevo — heredará la skill `cloudflare-zerotrust-ops` desde `_template/`
2. Sincronizar el workspace del nuevo agente (`Sync from Workspace`)
3. Verificar que los paquetes de `requirements.txt` se registran en `pending_review`
4. Aprobar e instalar los paquetes desde **Dashboard → Packages**
5. Ejecutar la skill con el caso base y verificar el resultado esperado
