### PR TITLE
promote(skill): home-assistant v0.1.0

### DIFF
--- a/workspaces/_template/skills/home-assistant/SKILL.md
+++ b/workspaces/_template/skills/home-assistant/SKILL.md
@@ -2,20 +2,6 @@
 
 Control Home Assistant smart home devices using the Assist (Conversation) API by passing natural language directly to Home Assistant's built-in NLU for fast, token-efficient control.
 
----
-name: homeassistant-assist
-description: Control Home Assistant smart home devices using the Assist (Conversation) API. Use this skill when the user wants to control smart home entities - lights, switches, thermostats, covers, vacuums, media players, or any other smart device. Passes natural language directly to Home Assistant's built-in NLU for fast, token-efficient control.
-homepage: https://github.com/DevelopmentCats/homeassistant-assist
-metadata:
-  openclaw:
-    emoji: "🏠"
-    requires:
-      bins: ["curl"]
-      env: ["HASS_SERVER", "HASS_TOKEN"]
-    primaryEnv: "HASS_TOKEN"
----
-
-# Home Assistant Assist
 
 Control smart home devices by passing natural language to Home Assistant's Assist (Conversation) API. **Fire and forget** — trust Assist to handle intent parsing, entity resolution, and execution.
 
@@ -28,10 +14,12 @@ Use this skill when the user wants to **control or query any smart home device**
 Pass the user's request directly to Assist:
 
 ```bash
+# Build the JSON payload safely to avoid shell injection from user input
+PAYLOAD=$(jq -n --arg text "USER REQUEST HERE" --arg lang "en" '{text: $text, language: $lang}')
 curl -s -X POST "$HASS_SERVER/api/conversation/process" \
   -H "Authorization: Bearer $HASS_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"text": "USER REQUEST HERE", "language": "en"}'
+  -d "$PAYLOAD"
 ```
 
 **Trust Assist.** It handles:
@@ -65,15 +53,18 @@ These are **suggestions for improving HA config**, not skill failures. The skill
 
 ## Setup
 
-Set environment variables in OpenClaw config:
+Store your Home Assistant credentials using the platform credential store:
 
-```json
-{
-  "env": {
-    "HASS_SERVER": "https://your-homeassistant-url",
-    "HASS_TOKEN": "your-long-lived-access-token"
-  }
-}
+```
+set_credential(name="hass_token", value="your-long-lived-access-token", description="Home Assistant long-lived access token")
+set_credential(name="hass_server", value="https://your-homeassistant-url", description="Home Assistant base URL")
+```
+
+Then retrieve them at runtime:
+
+```
+HASS_TOKEN = get_credential("hass_token")["value"]
+HASS_SERVER = get_credential("hass_server")["value"]
 ```
 
 Generate a token: Home Assistant → Profile → Long-Lived Access Tokens → Create Token

--- a/workspaces/_template/skills/home-assistant/SKILL.md
+++ b/workspaces/_template/skills/home-assistant/SKILL.md
@@ -1,0 +1,127 @@
+# Home Assistant Assist
+
+Control Home Assistant smart home devices using the Assist (Conversation) API by passing natural language directly to Home Assistant's built-in NLU for fast, token-efficient control.
+
+---
+name: homeassistant-assist
+description: Control Home Assistant smart home devices using the Assist (Conversation) API. Use this skill when the user wants to control smart home entities - lights, switches, thermostats, covers, vacuums, media players, or any other smart device. Passes natural language directly to Home Assistant's built-in NLU for fast, token-efficient control.
+homepage: https://github.com/DevelopmentCats/homeassistant-assist
+metadata:
+  openclaw:
+    emoji: "🏠"
+    requires:
+      bins: ["curl"]
+      env: ["HASS_SERVER", "HASS_TOKEN"]
+    primaryEnv: "HASS_TOKEN"
+---
+
+# Home Assistant Assist
+
+Control smart home devices by passing natural language to Home Assistant's Assist (Conversation) API. **Fire and forget** — trust Assist to handle intent parsing, entity resolution, and execution.
+
+## When to Use This Skill
+
+Use this skill when the user wants to **control or query any smart home device**. If it's in Home Assistant, Assist can handle it.
+
+## How It Works
+
+Pass the user's request directly to Assist:
+
+```bash
+curl -s -X POST "$HASS_SERVER/api/conversation/process" \
+  -H "Authorization: Bearer $HASS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "USER REQUEST HERE", "language": "en"}'
+```
+
+**Trust Assist.** It handles:
+- Intent parsing
+- Fuzzy entity name matching
+- Area-aware commands
+- Execution
+- Error responses
+
+## Handling Responses
+
+**Just relay what Assist says.** The `response.speech.plain.speech` field contains the human-readable result.
+
+- `"Turned on the light"` → Success, tell the user
+- `"Sorry, I couldn't understand that"` → Assist couldn't parse it
+- `"Sorry, there are multiple devices called X"` → Ambiguous name
+
+**Don't over-interpret.** If Assist says it worked, it worked. Trust the response.
+
+## When Assist Returns an Error
+
+Only if Assist returns an error (`response_type: "error"`), you can **suggest HA-side improvements**:
+
+| Error | Suggestion |
+|-------|------------|
+| `no_intent_match` | "HA didn't recognize that command" |
+| `no_valid_targets` | "Try checking the entity name in HA, or add an alias" |
+| Multiple devices | "There may be duplicate names — consider adding unique aliases in HA" |
+
+These are **suggestions for improving HA config**, not skill failures. The skill did its job — it passed the request to Assist.
+
+## Setup
+
+Set environment variables in OpenClaw config:
+
+```json
+{
+  "env": {
+    "HASS_SERVER": "https://your-homeassistant-url",
+    "HASS_TOKEN": "your-long-lived-access-token"
+  }
+}
+```
+
+Generate a token: Home Assistant → Profile → Long-Lived Access Tokens → Create Token
+
+## API Reference
+
+### Endpoint
+
+```
+POST /api/conversation/process
+```
+
+**Note:** Use `/api/conversation/process`, NOT `/api/services/conversation/process`.
+
+### Request
+
+```json
+{
+  "text": "turn on the kitchen lights",
+  "language": "en"
+}
+```
+
+### Response
+
+```json
+{
+  "response": {
+    "speech": {
+      "plain": {"speech": "Turned on the light"}
+    },
+    "response_type": "action_done",
+    "data": {
+      "success": [{"name": "Kitchen Light", "id": "light.kitchen"}],
+      "failed": []
+    }
+  }
+}
+```
+
+## Philosophy
+
+- **Trust Assist** — It knows the user's HA setup better than we do
+- **Fire and forget** — Pass the request, relay the response
+- **Don't troubleshoot** — If something doesn't work, suggest HA config improvements
+- **Keep it simple** — One API call, natural language in, natural language out
+
+## Links
+
+- [Home Assistant Conversation API Docs](https://developers.home-assistant.io/docs/intent_conversation_api/)
+

--- a/workspaces/_template/skills/home-assistant/manifest.json
+++ b/workspaces/_template/skills/home-assistant/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "home-assistant",
+  "description": "Control Home Assistant smart home devices using the Assist (Conversation) API by passing natural language directly to Home Assistant's built-in NLU for fast, token-efficient control.",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## Promoción: skill/home-assistant v0.1.0

**Origen:** catálogo global
**Patches aplicados:** 0 (último: N/A)
**Validación de código:** OK

### Descripción
Control Home Assistant smart home devices using the Assist (Conversation) API by passing natural language directly to Home Assistant's built-in NLU for fast, token-efficient control.

### Dependencias Python
_Ninguna detectada._

### Escaneo de seguridad
✅ Sin problemas detectados.

### Cambios en `_template/`
El diff está incluido en `promote.patch`.

### Cómo testear
1. Crear un agente nuevo — heredará la skill `home-assistant` desde `_template/`
2. Sincronizar el workspace del nuevo agente (`Sync from Workspace`)
3. Verificar que los paquetes de `requirements.txt` se registran en `pending_review`
4. Aprobar e instalar los paquetes desde **Dashboard → Packages**
5. Ejecutar la skill con el caso base y verificar el resultado esperado
