### PR TITLE
Add robust workspace tool management and cleanup utility

### DIFF
--- a/docs/workspace-tool-management.md
+++ b/docs/workspace-tool-management.md
@@ -1,0 +1,204 @@
+# Workspace tool management
+
+This document defines the lifecycle and migration rules for Autobot workspace tools.
+It exists to avoid stale catalog entries such as `example-tool-v2` being shown as
+active tools after the code has already moved to `example-tool`.
+
+## Policy
+
+1. **Use the system version field**: every tool keeps its version in
+   `tools/<slug>/manifest.json` under `version`.
+2. **Do not encode versions in names**: names such as `cloudflare-csp-updater-token-v3`
+   are invalid for active tools. Use `cloudflare-csp-updater-token` with
+   `"version": "1.3.0"` instead.
+3. **Use stable base + function names**: choose names that group naturally by
+   domain and action, for example:
+   - `cloudflare-csp-updater-token`
+   - `cloudflare-firewall-reader-token`
+   - `portainer-containers-agentcred`
+   - `notion-page-style-rewriter-token`
+4. **Remove superseded tools**: once a newer implementation is consolidated into
+   the canonical slug, obsolete `-vN` directories and catalog records must be
+   unregistered, not merely marked deprecated.
+5. **Keep variants only when they represent different behavior**, not versions:
+   - acceptable: `*-token`, `*-agentcred`, `*-reader`, `*-publisher`;
+   - not acceptable: `*-v2`, `*-v3`, `*-new`, `*-final`.
+
+## Why filesystem cleanup is not enough
+
+The runtime may expose tools from an internal registry/catalog in addition to the
+workspace filesystem. Removing `tools/example-v2/` can leave stale catalog rows if
+registration is append-only or cache-based. A robust system must reconcile both:
+
+- filesystem source of truth (`tools/<slug>/manifest.json`, `tool.py`);
+- persisted tool registry/catalog entries;
+- generated inventory such as `TOOLS.md`;
+- references from skills and docs.
+
+## Desired reconciliation flow
+
+1. Discover installed tools from the workspace filesystem.
+2. Discover registered tools from the platform registry.
+3. Compute canonical slugs by stripping only semantic suffixes matching `-v[0-9]+`.
+4. For each canonical group:
+   - choose the newest/best implementation;
+   - move it to `tools/<canonical>/`;
+   - set `manifest.name = <canonical>`;
+   - set/increment `manifest.version`;
+   - remove `deprecated`, `replacement`, and stale `supersedes` references;
+   - delete obsolete `tools/<canonical>-vN/` directories;
+   - unregister or disable obsolete registry rows.
+5. Regenerate `TOOLS.md` from active registry/filesystem state.
+6. Scan skills/docs for obsolete names and rewrite references to canonical names.
+7. Fail CI if a new `tools/*-vN` directory appears.
+
+## CLI utility
+
+This PR adds `scripts/workspace_tools_manager.py`, a dependency-free utility that
+can audit and repair existing installations.
+
+### Audit only
+
+```bash
+python scripts/workspace_tools_manager.py --root . --json
+```
+
+Example failing output:
+
+```json
+{
+  "ok": false,
+  "tool_count": 3,
+  "versioned_tool_dirs": ["cloudflare-csp-updater-token-v3"],
+  "findings": [
+    {
+      "severity": "error",
+      "code": "VERSION_IN_NAME",
+      "path": "/workspace/tools/cloudflare-csp-updater-token-v3",
+      "message": "Tool name 'cloudflare-csp-updater-token-v3' encodes a version; use 'cloudflare-csp-updater-token' and manifest.version instead.",
+      "fix": "migrate-versioned"
+    }
+  ]
+}
+```
+
+### Repair existing installations
+
+Dry run:
+
+```bash
+python scripts/workspace_tools_manager.py --root . --repair
+```
+
+Apply:
+
+```bash
+python scripts/workspace_tools_manager.py --root . --repair --apply
+```
+
+What it fixes:
+
+- `tools/foo-v2` + `tools/foo` -> keeps the best implementation at `tools/foo`;
+- `tools/foo-v3` only -> renames it to `tools/foo`;
+- missing `manifest.version` -> adds `0.1.0`;
+- `manifest.name` mismatch -> syncs it with the directory name;
+- stale `supersedes`/`replacement` references to versioned tools -> removes them;
+- docs/skills references to `*-vN` -> reports them for manual or automated rewrite.
+
+## Registry/catalog integration recommendation
+
+The platform should expose a management API/command with these operations:
+
+```python
+class ToolRegistry:
+    def list_registered_tools(self, agent_id: str) -> list[RegisteredTool]: ...
+    def register_or_update(self, agent_id: str, slug: str, manifest: dict, code_hash: str) -> None: ...
+    def unregister(self, agent_id: str, slug: str, reason: str) -> None: ...
+    def disable(self, agent_id: str, slug: str, reason: str) -> None: ...
+```
+
+Suggested reconciliation pseudocode:
+
+```python
+fs_tools = discover_tools(workspace / "tools")
+registry_tools = registry.list_registered_tools(agent_id)
+active_fs_slugs = {tool.slug for tool in fs_tools if not tool.versioned}
+
+for registered in registry_tools:
+    if registered.slug not in active_fs_slugs:
+        registry.unregister(agent_id, registered.slug, reason="not present in filesystem source of truth")
+
+for tool in fs_tools:
+    if tool.versioned:
+        raise PolicyError(f"Version encoded in tool name: {tool.slug}")
+    registry.register_or_update(agent_id, tool.slug, tool.manifest, code_hash(tool.tool_path))
+```
+
+## CI guard
+
+Add a CI step or pre-merge check:
+
+```bash
+python scripts/workspace_tools_manager.py --root . --json
+```
+
+The command exits with status `2` when any error-level finding exists, so it can
+block PRs that introduce `tools/*-vN` or missing manifests.
+
+## Migration cases covered
+
+### Case 1: base + v2 exist
+
+Before:
+
+```text
+tools/mealie-recipe-reader/
+tools/mealie-recipe-reader-v2/
+```
+
+After repair:
+
+```text
+tools/mealie-recipe-reader/       # contains best implementation
+tools/mealie-recipe-reader-v2/    # removed
+```
+
+### Case 2: only a versioned tool exists
+
+Before:
+
+```text
+tools/cloudflare-firewall-reader-token-v3/
+```
+
+After:
+
+```text
+tools/cloudflare-firewall-reader-token/
+```
+
+### Case 3: credential variants are legitimate
+
+These are not versions and should remain separate:
+
+```text
+tools/notion-page-search-token/
+tools/notion-page-search-agentcred/
+```
+
+### Case 4: stale registry entry remains after filesystem cleanup
+
+If the UI still shows `cloudflare-csp-updater-token-v3` after deleting the folder,
+the registry must be reconciled/unregistered. The filesystem repair cannot remove
+database rows by itself; the platform reconciliation API above is required.
+
+## Developer checklist
+
+- [ ] Run audit and capture JSON report.
+- [ ] Run repair dry-run.
+- [ ] Apply repair in a branch.
+- [ ] Run tests: `python -m pytest tests/test_workspace_tools_manager.py`.
+- [ ] Reconcile platform registry/catalog against filesystem active tools.
+- [ ] Regenerate `TOOLS.md`.
+- [ ] Verify UI no longer lists obsolete `-vN` tools.
+- [ ] Add CI guard to prevent regressions.

--- a/scripts/workspace_tools_manager.py
+++ b/scripts/workspace_tools_manager.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Workspace tools management utility.
+
+Audits and repairs Autobot workspace tool installations so tool names stay
+stable while versions live in each tool manifest.
+
+Policy enforced by default:
+- Tool directory/name must not include semantic version suffixes like -v2/-v3.
+- Every tool must have a manifest.json and tool.py.
+- Every manifest must expose a system version field.
+- Deprecated/superseded tool directories can be removed after a dry-run report.
+- Existing installations can be migrated by copying a versioned tool into its
+  canonical directory and deleting the obsolete versioned directory.
+
+The script is intentionally dependency-free and safe-by-default: it only writes
+when --apply is passed. Use --json for CI/catalog sync automation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+VERSION_SUFFIX_RE = re.compile(r"^(?P<base>.+)-v(?P<num>[0-9]+)$")
+SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+DEFAULT_VERSION = "0.1.0"
+
+
+@dataclass
+class Finding:
+    severity: str
+    code: str
+    path: str
+    message: str
+    fix: Optional[str] = None
+
+
+@dataclass
+class ToolInfo:
+    slug: str
+    path: str
+    manifest_path: str
+    tool_path: str
+    manifest: Dict[str, Any]
+    versioned: bool
+    canonical_slug: str
+    suffix_version: Optional[int]
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        return {"__json_error__": str(exc)}
+
+
+def write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def canonicalize_slug(slug: str) -> Tuple[str, Optional[int]]:
+    match = VERSION_SUFFIX_RE.match(slug)
+    if not match:
+        return slug, None
+    return match.group("base"), int(match.group("num"))
+
+
+def discover_tools(tools_dir: Path) -> List[ToolInfo]:
+    if not tools_dir.exists():
+        return []
+    tools: List[ToolInfo] = []
+    for path in sorted(p for p in tools_dir.iterdir() if p.is_dir()):
+        slug = path.name
+        canonical, suffix = canonicalize_slug(slug)
+        manifest_path = path / "manifest.json"
+        tool_path = path / "tool.py"
+        tools.append(
+            ToolInfo(
+                slug=slug,
+                path=str(path),
+                manifest_path=str(manifest_path),
+                tool_path=str(tool_path),
+                manifest=read_json(manifest_path),
+                versioned=suffix is not None,
+                canonical_slug=canonical,
+                suffix_version=suffix,
+            )
+        )
+    return tools
+
+
+def audit_tools(tools: Iterable[ToolInfo]) -> List[Finding]:
+    findings: List[Finding] = []
+    seen: Dict[str, List[ToolInfo]] = {}
+    for tool in tools:
+        seen.setdefault(tool.canonical_slug, []).append(tool)
+        if tool.versioned:
+            findings.append(Finding(
+                "error", "VERSION_IN_NAME", tool.path,
+                f"Tool name '{tool.slug}' encodes a version; use '{tool.canonical_slug}' and manifest.version instead.",
+                "migrate-versioned"
+            ))
+        if not Path(tool.tool_path).exists():
+            findings.append(Finding("error", "MISSING_TOOL_PY", tool.tool_path, "tool.py is required."))
+        if not Path(tool.manifest_path).exists():
+            findings.append(Finding("error", "MISSING_MANIFEST", tool.manifest_path, "manifest.json is required.", "create-manifest"))
+            continue
+        if "__json_error__" in tool.manifest:
+            findings.append(Finding("error", "INVALID_MANIFEST_JSON", tool.manifest_path, tool.manifest["__json_error__"]))
+            continue
+        name = tool.manifest.get("name")
+        if name and name != tool.slug:
+            findings.append(Finding("warning", "MANIFEST_NAME_MISMATCH", tool.manifest_path, f"manifest.name='{name}' differs from directory '{tool.slug}'.", "sync-manifest-name"))
+        version = tool.manifest.get("version")
+        if not version:
+            findings.append(Finding("error", "MISSING_SYSTEM_VERSION", tool.manifest_path, "manifest.version is required.", "set-version"))
+        elif not isinstance(version, str) or not SEMVER_RE.match(version):
+            findings.append(Finding("warning", "NON_SEMVER_VERSION", tool.manifest_path, f"manifest.version='{version}' is not semver-like."))
+        if tool.manifest.get("deprecated") is True:
+            findings.append(Finding("warning", "DEPRECATED_TOOL_VISIBLE", tool.path, "Deprecated tool directory is still installed/visible.", "remove-deprecated"))
+        for field in ("supersedes", "replacement"):
+            value = tool.manifest.get(field)
+            if isinstance(value, str) and VERSION_SUFFIX_RE.search(value):
+                findings.append(Finding("warning", "OBSOLETE_REFERENCE", tool.manifest_path, f"manifest.{field} references versioned tool '{value}'.", "remove-obsolete-reference"))
+            elif isinstance(value, list):
+                bad = [x for x in value if isinstance(x, str) and VERSION_SUFFIX_RE.search(x)]
+                if bad:
+                    findings.append(Finding("warning", "OBSOLETE_REFERENCE", tool.manifest_path, f"manifest.{field} references versioned tools {bad}.", "remove-obsolete-reference"))
+    for canonical, group in seen.items():
+        if len(group) > 1 and any(t.versioned for t in group):
+            names = ", ".join(t.slug for t in group)
+            findings.append(Finding("error", "DUPLICATE_CANONICAL_GROUP", f"tools/{canonical}", f"Multiple implementations for same canonical tool: {names}.", "migrate-versioned"))
+    return findings
+
+
+def choose_best_tool(group: List[ToolInfo]) -> ToolInfo:
+    """Choose implementation to keep during repair.
+
+    Preference order:
+    1. highest explicit manifest.version if semver-like;
+    2. highest suffix number (-v3 beats -v2);
+    3. largest tool.py content size as a pragmatic proxy for richer implementation;
+    4. canonical base directory for tie-break stability.
+    """
+    def semver_tuple(version: Any) -> Tuple[int, int, int]:
+        if isinstance(version, str):
+            m = re.match(r"^([0-9]+)\.([0-9]+)\.([0-9]+)", version)
+            if m:
+                return tuple(map(int, m.groups()))  # type: ignore[return-value]
+        return (0, 0, 0)
+
+    def score(tool: ToolInfo) -> Tuple[Tuple[int, int, int], int, int, int]:
+        size = Path(tool.tool_path).stat().st_size if Path(tool.tool_path).exists() else 0
+        suffix = tool.suffix_version or 0
+        canonical_bonus = 1 if not tool.versioned else 0
+        return (semver_tuple(tool.manifest.get("version")), suffix, size, canonical_bonus)
+
+    return sorted(group, key=score, reverse=True)[0]
+
+
+def next_patch_version(version: Any) -> str:
+    if isinstance(version, str):
+        m = re.match(r"^([0-9]+)\.([0-9]+)\.([0-9]+)", version)
+        if m:
+            major, minor, patch = map(int, m.groups())
+            return f"{major}.{minor}.{patch + 1}"
+    return "1.0.0"
+
+
+def repair_installation(root: Path, apply: bool = False, remove_obsolete_refs: bool = True) -> List[Finding]:
+    tools_dir = root / "tools"
+    tools = discover_tools(tools_dir)
+    findings = audit_tools(tools)
+    actions: List[Finding] = []
+
+    by_canonical: Dict[str, List[ToolInfo]] = {}
+    for t in tools:
+        by_canonical.setdefault(t.canonical_slug, []).append(t)
+
+    for canonical, group in sorted(by_canonical.items()):
+        versioned_members = [t for t in group if t.versioned]
+        if not versioned_members:
+            continue
+        best = choose_best_tool(group)
+        canonical_path = tools_dir / canonical
+        actions.append(Finding("info", "PLAN_CANONICALIZE", str(canonical_path), f"Keep '{best.slug}' as canonical '{canonical}' and remove {[t.slug for t in versioned_members]}."))
+        if apply:
+            if best.slug != canonical:
+                if canonical_path.exists():
+                    backup = tools_dir / f".{canonical}.pre-tool-manager-backup"
+                    if backup.exists():
+                        shutil.rmtree(backup)
+                    shutil.copytree(canonical_path, backup)
+                    shutil.rmtree(canonical_path)
+                shutil.copytree(Path(best.path), canonical_path)
+            manifest_path = canonical_path / "manifest.json"
+            manifest = read_json(manifest_path)
+            if "__json_error__" in manifest:
+                manifest = {}
+            manifest["name"] = canonical
+            manifest.setdefault("description", f"Workspace tool {canonical}")
+            manifest["version"] = next_patch_version(manifest.get("version", DEFAULT_VERSION))
+            manifest.pop("deprecated", None)
+            manifest.pop("replacement", None)
+            if remove_obsolete_refs:
+                manifest.pop("supersedes", None)
+            manifest.setdefault("x-tool-management", {})
+            manifest["x-tool-management"].update({
+                "canonical_name": canonical,
+                "version_policy": "manifest.version",
+                "name_policy": "no version suffix in tool directory/name",
+                "managed_by": "scripts/workspace_tools_manager.py",
+            })
+            write_json(manifest_path, manifest)
+            for obsolete in versioned_members:
+                obsolete_path = Path(obsolete.path)
+                if obsolete_path.exists() and obsolete_path != canonical_path:
+                    shutil.rmtree(obsolete_path)
+
+    if apply:
+        for tool in discover_tools(tools_dir):
+            mp = Path(tool.manifest_path)
+            if not mp.exists():
+                write_json(mp, {"name": tool.slug, "version": DEFAULT_VERSION, "description": f"Workspace tool {tool.slug}"})
+                continue
+            manifest = read_json(mp)
+            if "__json_error__" in manifest:
+                continue
+            changed = False
+            if manifest.get("name") != tool.slug:
+                manifest["name"] = tool.slug
+                changed = True
+            if not manifest.get("version"):
+                manifest["version"] = DEFAULT_VERSION
+                changed = True
+            if remove_obsolete_refs:
+                for key in ("supersedes", "replacement"):
+                    value = manifest.get(key)
+                    if isinstance(value, str) and VERSION_SUFFIX_RE.search(value):
+                        manifest.pop(key, None); changed = True
+                    elif isinstance(value, list):
+                        filtered = [x for x in value if not (isinstance(x, str) and VERSION_SUFFIX_RE.search(x))]
+                        if filtered != value:
+                            if filtered:
+                                manifest[key] = filtered
+                            else:
+                                manifest.pop(key, None)
+                            changed = True
+            if changed:
+                write_json(mp, manifest)
+    return findings + actions
+
+
+def scan_references(root: Path, patterns: Optional[List[str]] = None) -> List[Finding]:
+    patterns = patterns or [r"\b[a-z0-9][a-z0-9-]*-v[0-9]+\b"]
+    regexes = [re.compile(p) for p in patterns]
+    findings: List[Finding] = []
+    ignored_dirs = {".git", "__pycache__", ".pytest_cache", "node_modules"}
+    for path in root.rglob("*"):
+        if any(part in ignored_dirs for part in path.parts):
+            continue
+        if not path.is_file() or path.suffix in {".pyc", ".png", ".jpg", ".jpeg", ".gif", ".zip", ".gz"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for regex in regexes:
+            matches = sorted(set(regex.findall(text)))
+            if matches:
+                findings.append(Finding("warning", "VERSIONED_REFERENCE", str(path), f"Found versioned tool references: {matches}", "update-reference"))
+    return findings
+
+
+def build_report(root: Path, include_refs: bool = True) -> Dict[str, Any]:
+    tools = discover_tools(root / "tools")
+    findings = audit_tools(tools)
+    if include_refs:
+        findings.extend(scan_references(root))
+    return {
+        "tool_count": len(tools),
+        "versioned_tool_dirs": [t.slug for t in tools if t.versioned],
+        "findings": [asdict(f) for f in findings],
+        "ok": not any(f.severity == "error" for f in findings),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit and repair Autobot workspace tools.")
+    parser.add_argument("--root", default=".", help="Workspace/repository root. Default: current directory.")
+    parser.add_argument("--apply", action="store_true", help="Apply repairs. Without this flag the command is dry-run only.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    parser.add_argument("--no-ref-scan", action="store_true", help="Skip scanning docs/skills/tools for versioned references.")
+    parser.add_argument("--repair", action="store_true", help="Plan/apply repair of existing installations.")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.repair:
+        repair_installation(root, apply=args.apply)
+    report = build_report(root, include_refs=not args.no_ref_scan)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"Tool count: {report['tool_count']}")
+        print(f"Versioned tool dirs: {report['versioned_tool_dirs'] or 'none'}")
+        for f in report["findings"]:
+            print(f"[{f['severity']}] {f['code']} {f['path']}: {f['message']}")
+        print("OK" if report["ok"] else "FAILED")
+    return 0 if report["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workspace_tools_manager.py
+++ b/tests/test_workspace_tools_manager.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+import importlib.util
+import sys
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "workspace_tools_manager.py"
+spec = importlib.util.spec_from_file_location("workspace_tools_manager", MODULE_PATH)
+manager = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = manager
+spec.loader.exec_module(manager)
+
+
+def write_tool(root: Path, slug: str, version="0.1.0", body="def handler(**kwargs): return {}", **manifest_extra):
+    d = root / "tools" / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "tool.py").write_text(body, encoding="utf-8")
+    manifest = {"name": slug, "version": version, "description": slug}
+    manifest.update(manifest_extra)
+    (d / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return d
+
+
+def test_audit_flags_version_in_name(tmp_path):
+    write_tool(tmp_path, "cloudflare-csp-updater-token-v3")
+    report = manager.build_report(tmp_path, include_refs=False)
+    codes = {f["code"] for f in report["findings"]}
+    assert "VERSION_IN_NAME" in codes
+    assert report["ok"] is False
+
+
+def test_repair_migrates_highest_version_to_canonical_and_removes_obsolete(tmp_path):
+    write_tool(tmp_path, "demo-tool", version="0.1.0", body="def handler(**kwargs): return {'old': True}")
+    write_tool(tmp_path, "demo-tool-v2", version="0.2.0", body="def handler(**kwargs): return {'new': True}")
+    manager.repair_installation(tmp_path, apply=True)
+    assert (tmp_path / "tools" / "demo-tool").exists()
+    assert not (tmp_path / "tools" / "demo-tool-v2").exists()
+    assert "new" in (tmp_path / "tools" / "demo-tool" / "tool.py").read_text()
+    manifest = json.loads((tmp_path / "tools" / "demo-tool" / "manifest.json").read_text())
+    assert manifest["name"] == "demo-tool"
+    assert manifest["version"] == "0.2.1"
+    assert manifest["x-tool-management"]["version_policy"] == "manifest.version"
+
+
+def test_single_versioned_tool_is_renamed_to_base(tmp_path):
+    write_tool(tmp_path, "notion-audit-style-applier-token-v2", version="1.0.0")
+    manager.repair_installation(tmp_path, apply=True)
+    assert (tmp_path / "tools" / "notion-audit-style-applier-token").exists()
+    assert not (tmp_path / "tools" / "notion-audit-style-applier-token-v2").exists()
+
+
+def test_scan_references_finds_docs_and_skills(tmp_path):
+    (tmp_path / "skills" / "x").mkdir(parents=True)
+    (tmp_path / "skills" / "x" / "SKILL.md").write_text("Use homeassistant-assist-v2", encoding="utf-8")
+    findings = manager.scan_references(tmp_path)
+    assert any(f.code == "VERSIONED_REFERENCE" for f in findings)
+
+
+def test_repair_removes_obsolete_manifest_references(tmp_path):
+    write_tool(tmp_path, "demo-tool", version="1.0.0", supersedes=["demo-tool-v2"])
+    manager.repair_installation(tmp_path, apply=True)
+    manifest = json.loads((tmp_path / "tools" / "demo-tool" / "manifest.json").read_text())
+    assert "supersedes" not in manifest


### PR DESCRIPTION
## Summary

Adds a robust workspace tool management proposal and implementation to enforce the agreed best practices:

- keep versions in `manifest.json`, not in tool names;
- use stable base + function slugs;
- remove superseded tools from active installations;
- repair existing installations where `*-vN` tools remain visible;
- provide a registry/catalog reconciliation design for stale UI entries.

## Added

- `scripts/workspace_tools_manager.py`
  - dependency-free CLI to audit workspace tools;
  - detects `tools/*-vN`, missing `tool.py`, missing/invalid manifests, missing versions, deprecated visible tools and stale versioned references;
  - supports dry-run and `--repair --apply` migration;
  - canonicalizes `foo-v2` / `foo-v3` into `foo` and removes obsolete folders;
  - normalizes `manifest.name` and `manifest.version`;
  - produces JSON output for CI/catalog automation.

- `tests/test_workspace_tools_manager.py`
  - covers version-in-name detection;
  - base+versioned migration;
  - only-versioned rename;
  - stale docs/skills reference detection;
  - obsolete manifest reference cleanup.

- `docs/workspace-tool-management.md`
  - policy and naming rules;
  - migration flow;
  - examples and cases;
  - registry/catalog integration recommendation to unregister stale rows;
  - CI guard instructions;
  - developer checklist.

## Existing installation repair

Example commands:

```bash
python scripts/workspace_tools_manager.py --root . --json
python scripts/workspace_tools_manager.py --root . --repair
python scripts/workspace_tools_manager.py --root . --repair --apply
```

## Important note

Filesystem cleanup alone may not remove stale tools from the UI if the platform keeps an internal registry. The doc includes a registry reconciliation API/pseudocode so existing installations can be fully repaired by unregistering rows not present in the filesystem source of truth.

## Validation

- `python -m py_compile /tmp/tool_mgmt_pr/scripts/workspace_tools_manager.py`
- smoke-tested audit/repair import flow in a temporary workspace.

No secrets or private infrastructure details included.