### PR TITLE
fix(runtime): graceful partial summary on max tool rounds

### DIFF
--- a/app/dashboard/logs_views.py
+++ b/app/dashboard/logs_views.py
@@ -13,7 +13,7 @@ DEFAULT_LIMIT = 200
 MAX_LIMIT = 2000
 
 # Execution-log ("Executions" tab) filter vocabularies.
-RUN_STATUSES = ["running", "completed", "error"]
+RUN_STATUSES = ["running", "completed", "partial", "error"]
 RUN_TRIGGERS = ["message", "cron", "heartbeat", "delegation", "internal", "auto_review", "patch_review"]
 RUNS_DEFAULT_LIMIT = 50
 

--- a/app/runtime/agent_runner.py
+++ b/app/runtime/agent_runner.py
@@ -12,6 +12,28 @@ from app.runtime.tool_executor import execute as execute_tool
 # the ``max_tool_rounds`` column on the ``agents`` table.
 DEFAULT_MAX_TOOL_ROUNDS = 20
 
+# When this many tool-call rounds remain, inject a one-shot system notice so the
+# model can wind down and summarize instead of being cut off mid-task. See #25.
+_LOW_BUDGET_REMAINING = 2
+
+_LOW_BUDGET_NUDGE = (
+    "SYSTEM NOTICE: Your tool-call-round budget is almost exhausted"
+    " ({remaining} round(s) left of {limit}). Do not start new lines of"
+    " investigation. Call a tool only if it is essential to finish the task;"
+    " otherwise stop calling tools and give your best final answer now,"
+    " summarizing what you completed, what you found, and any safe next steps."
+)
+
+# Injected (with tools disabled) for the single finalization turn once the hard
+# round cap is hit, so the user gets a partial synthesis instead of silent loss.
+_FINALIZE_PROMPT = (
+    "SYSTEM ENFORCEMENT: The maximum tool-call-round budget has been reached."
+    " You may not call any more tools. Using the tool results gathered so far,"
+    " write a final answer for the user: summarize the actions completed, the"
+    " key findings, what remains blocked, and concrete safe next steps. Be"
+    " concise and do not apologize."
+)
+
 # Per-call cap on what goes back into the *model's* message stream. The full
 # tool output is still persisted in ``tool_executions`` — this only trims
 # what the model sees on the next round so a single fat response (e.g. a
@@ -125,10 +147,30 @@ def run(agent, session, user_message, run_id):
         or DEFAULT_MAX_TOOL_ROUNDS
     )
 
+    # Termination/observability bookkeeping surfaced on the final chunk (#25).
+    tool_executions_count = 0
+    last_tool_name = None
+    last_tool_status = None
+    low_budget_warned = False
+
     try:
         for round_num in range(max_rounds):
             full_response = ""
             tool_calls = None
+
+            # Warn the model once when only a couple of rounds remain so it can
+            # wind down gracefully instead of being hard-cut mid-task.
+            remaining = max_rounds - round_num
+            if not low_budget_warned and remaining <= _LOW_BUDGET_REMAINING < max_rounds:
+                low_budget_warned = True
+                messages.append({
+                    "role": "system",
+                    "content": _LOW_BUDGET_NUDGE.format(remaining=remaining, limit=max_rounds),
+                })
+                current_app.logger.info(
+                    "agent_runner low-budget warning: agent=%s round=%d remaining=%d",
+                    agent.id, round_num, remaining,
+                )
 
             # Trim accumulated agentic pairs that would push the context over
             # budget. Must happen before the API call so the model never sees
@@ -227,6 +269,11 @@ def run(agent, session, user_message, run_id):
                     return
 
                 result = execute_tool(run_id, agent, tool_name, arguments)
+                tool_executions_count += 1
+                last_tool_name = tool_name
+                last_tool_status = (
+                    "error" if isinstance(result, dict) and result.get("error") else "ok"
+                )
 
                 yield json.dumps({"type": "tool_result", "data": {"tool": tool_name, "result": result}})
 
@@ -239,8 +286,60 @@ def run(agent, session, user_message, run_id):
                     "content": _cap_tool_result_content(result),
                 })
 
-        # Hit max rounds
-        yield json.dumps({"type": "error", "data": "Maximum tool call rounds reached"})
+        # Hit the hard round cap. Rather than dropping the task on the floor,
+        # give the model one final no-tool turn to synthesize a partial answer
+        # from the results gathered so far (#25).
+        meta = {
+            "termination_reason": "max_tool_rounds",
+            "tool_round_limit": max_rounds,
+            "tool_rounds_used": max_rounds,
+            "tool_executions_count": tool_executions_count,
+            "last_tool_name": last_tool_name,
+            "last_tool_status": last_tool_status,
+            "partial": True,
+        }
+        current_app.logger.warning(
+            "agent_runner max_tool_rounds: agent=%s run=%s limit=%d execs=%d last_tool=%s/%s",
+            agent.id, run_id, max_rounds, tool_executions_count,
+            last_tool_name, last_tool_status,
+        )
+
+        _trim_inloop_messages(messages, budget, _fixed_len)
+        messages.append({"role": "system", "content": _FINALIZE_PROMPT})
+
+        final_response = ""
+        try:
+            for delta_type, delta_data in stream_chat_completion(agent, messages, None):
+                if delta_type == "content":
+                    final_response += delta_data
+                    yield json.dumps({"type": "token", "data": delta_data})
+                elif delta_type == "usage":
+                    usage_total["input_tokens"] += delta_data.get("input_tokens", 0)
+                    usage_total["output_tokens"] += delta_data.get("output_tokens", 0)
+        except Exception as e:
+            # Even the summarization turn failed — fall back to a clear error so
+            # the run is still recorded, now with structured context.
+            current_app.logger.error("agent_runner finalization turn failed: %s", e)
+            yield json.dumps({
+                "type": "error",
+                "data": "Maximum tool call rounds reached",
+                "meta": meta,
+            })
+            return
+
+        if not final_response.strip():
+            final_response = (
+                "I reached my tool-call-round limit before finishing this task. "
+                "Partial work was completed but I could not synthesize a final "
+                "summary. Please re-run with a narrower request to continue."
+            )
+
+        yield json.dumps({
+            "type": "done",
+            "data": final_response,
+            "usage": usage_total,
+            "meta": meta,
+        })
     finally:
         # Drop the per-run read cache so long-lived workers don't leak.
         # Runs here if the generator completes, is closed early by the

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -11,6 +11,25 @@ from app.services.run_service import create_run, finish_run
 from app.services.session_service import add_message, get_or_create_session
 
 
+def _resolve_outcome(error, meta):
+    """Map runner chunks to a persisted (status, error_summary) pair.
+
+    A run that hit the tool-round cap (#25) still produced a partial answer, so
+    it is recorded as ``partial`` with a structured note rather than ``error``.
+    """
+    if error:
+        return "error", error
+    if meta and meta.get("termination_reason") == "max_tool_rounds":
+        note = (
+            "Reached max tool-call rounds "
+            f"({meta.get('tool_round_limit')}); returned a partial summary. "
+            f"tool_executions={meta.get('tool_executions_count')} "
+            f"last_tool={meta.get('last_tool_name')}/{meta.get('last_tool_status')}"
+        )
+        return "partial", note
+    return "completed", None
+
+
 def _prepare_run(agent_id, message, session_id=None, channel_type="web", trigger_type="message",
                   external_chat_id=None, external_user_id=None):
     """Common setup for both streaming and non-streaming agent execution."""
@@ -110,6 +129,7 @@ def stream_response(agent_id, message, session_id=None):
     # Run agent and stream response
     full_response = ""
     usage = {}
+    meta = None
     error = None
 
     try:
@@ -119,8 +139,10 @@ def stream_response(agent_id, message, session_id=None):
             if chunk["type"] == "done":
                 full_response = chunk.get("data", "")
                 usage = chunk.get("usage", {})
+                meta = chunk.get("meta")
             elif chunk["type"] == "error":
                 error = chunk.get("data", "Unknown error")
+                meta = chunk.get("meta")
 
             yield chunk_json
 
@@ -140,14 +162,15 @@ def stream_response(agent_id, message, session_id=None):
         _forward_to_matrix(agent, full_response)
 
     # Finalize run
+    status, error_summary = _resolve_outcome(error, meta)
     finish_run(
         run.id,
-        status="error" if error else "completed",
+        status=status,
         input_tokens=usage.get("input_tokens"),
         output_tokens=usage.get("output_tokens"),
-        error_summary=error,
+        error_summary=error_summary,
     )
-    _close_chat_objective(objective_id, succeeded=not error, error_summary=error)
+    _close_chat_objective(objective_id, succeeded=not error, error_summary=error_summary)
 
 
 def run_agent_non_streaming(agent_id, message, session_id=None, channel_type="web",
@@ -163,6 +186,7 @@ def run_agent_non_streaming(agent_id, message, session_id=None, channel_type="we
 
     full_response = ""
     usage = {}
+    meta = None
     error = None
 
     try:
@@ -171,8 +195,10 @@ def run_agent_non_streaming(agent_id, message, session_id=None, channel_type="we
             if chunk["type"] == "done":
                 full_response = chunk.get("data", "")
                 usage = chunk.get("usage", {})
+                meta = chunk.get("meta")
             elif chunk["type"] == "error":
                 error = chunk.get("data", "Unknown error")
+                meta = chunk.get("meta")
     except Exception as e:
         current_app.logger.error(f"Non-streaming agent error: {e}")
         error = str(e)
@@ -181,14 +207,15 @@ def run_agent_non_streaming(agent_id, message, session_id=None, channel_type="we
         add_message(session.id, role="assistant", content=full_response,
                     token_count=usage.get("output_tokens"))
 
+    status, error_summary = _resolve_outcome(error, meta)
     finish_run(
         run.id,
-        status="error" if error else "completed",
+        status=status,
         input_tokens=usage.get("input_tokens"),
         output_tokens=usage.get("output_tokens"),
-        error_summary=error,
+        error_summary=error_summary,
     )
-    _close_chat_objective(objective_id, succeeded=not error, error_summary=error)
+    _close_chat_objective(objective_id, succeeded=not error, error_summary=error_summary)
 
     return {"response": full_response, "error": error, "session_id": session.id, "run_id": run.id}
 

--- a/app/templates/dashboard/logs.html
+++ b/app/templates/dashboard/logs.html
@@ -220,6 +220,7 @@
 }
 .status-running   { background: rgba(59,130,246,0.2); color: #60a5fa; }
 .status-completed { background: rgba(34,197,94,0.2);  color: #4ade80; }
+.status-partial   { background: rgba(245,158,11,0.2); color: #fbbf24; }
 .status-error     { background: rgba(239,68,68,0.2);  color: #f87171; }
 .logs-filters {
     padding: 1rem 1.25rem;

--- a/tests/test_agent_runner_max_rounds.py
+++ b/tests/test_agent_runner_max_rounds.py
@@ -1,0 +1,148 @@
+"""Tests for the max-tool-round termination behavior (issue #25).
+
+When a run exhausts its tool-call-round budget the runner must no longer drop
+the task on the floor with a bare ``error``. Instead it should:
+
+  * warn the model once when the budget is nearly exhausted, and
+  * perform one final no-tool turn that synthesizes a partial answer, emitting
+    a ``done`` chunk carrying structured termination metadata.
+"""
+
+import json
+
+import pytest
+
+from app.runtime import agent_runner
+from app.services.chat_service import _resolve_outcome
+
+
+def _drain(agent, monkeypatch, *, max_rounds=3, final_content="PARTIAL SUMMARY"):
+    """Run the agent loop with a model stub that always calls a tool.
+
+    Returns ``(chunks, seen)`` where ``chunks`` is the list of decoded chunk
+    dicts and ``seen`` captures the messages handed to the finalization turn.
+    """
+    agent.max_tool_rounds = max_rounds
+
+    # A non-empty tool list so the loop's ``tools or None`` stays truthy and the
+    # finalization turn (tools=None) is distinguishable from a normal round.
+    tool_defs = [{"type": "function", "function": {"name": "noop", "parameters": {}}}]
+
+    seen = {"finalize_messages": None}
+    counter = {"n": 0}
+
+    def fake_stream(agent_, messages, tools):
+        if tools is None:
+            # Finalization turn: capture context, emit a summary.
+            seen["finalize_messages"] = [dict(m) for m in messages]
+            yield ("content", final_content)
+            yield ("usage", {"input_tokens": 5, "output_tokens": 3})
+            return
+        # Normal round: always request a tool call with varying args so the
+        # repeat-3-times guard never fires before the round cap is reached.
+        counter["n"] += 1
+        yield ("tool_calls", [{
+            "id": f"call-{counter['n']}",
+            "function": {"name": "noop", "arguments": json.dumps({"n": counter["n"]})},
+        }])
+
+    monkeypatch.setattr(agent_runner, "build_context", lambda a, s, m: [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": m},
+    ])
+    monkeypatch.setattr(agent_runner, "stream_chat_completion", fake_stream)
+    monkeypatch.setattr(agent_runner, "execute_tool", lambda *a, **k: {"ok": True})
+    monkeypatch.setattr("app.services.agent_budget_service.check_budget", lambda a: None)
+    monkeypatch.setattr("app.workspace.discovery.get_agent_tool_definitions", lambda a: tool_defs)
+    monkeypatch.setattr("app.runtime.context_budget.model_context_window", lambda *a, **k: 1_000_000)
+    monkeypatch.setattr("app.runtime.context_budget.effective_budget", lambda *a, **k: 1_000_000)
+    monkeypatch.setattr("app.runtime.tool_registry.forget_run_reads", lambda run_id: None)
+
+    chunks = [json.loads(c) for c in agent_runner.run(agent, session=None, user_message="audit everything", run_id=1)]
+    return chunks, seen
+
+
+class TestMaxRoundFinalization:
+    def test_emits_partial_done_with_metadata(self, app, agent, monkeypatch):
+        chunks, _ = _drain(agent, monkeypatch, max_rounds=3)
+
+        final = chunks[-1]
+        assert final["type"] == "done", f"expected graceful done, got {final}"
+        assert final["data"] == "PARTIAL SUMMARY"
+
+        meta = final["meta"]
+        assert meta["termination_reason"] == "max_tool_rounds"
+        assert meta["tool_round_limit"] == 3
+        assert meta["tool_rounds_used"] == 3
+        assert meta["tool_executions_count"] == 3
+        assert meta["last_tool_name"] == "noop"
+        assert meta["last_tool_status"] == "ok"
+        assert meta["partial"] is True
+
+        # The old hard-abort error must no longer be emitted.
+        assert not any(
+            c["type"] == "error" and c.get("data") == "Maximum tool call rounds reached"
+            for c in chunks
+        )
+
+    def test_low_budget_warning_injected_before_finalization(self, app, agent, monkeypatch):
+        _, seen = _drain(agent, monkeypatch, max_rounds=3)
+        finalize_msgs = seen["finalize_messages"]
+        assert finalize_msgs is not None
+        assert any(
+            m["role"] == "system" and "budget is almost exhausted" in m["content"]
+            for m in finalize_msgs
+        ), "expected a low-budget warning to have been injected"
+        # And the finalization prompt itself is present on the last turn.
+        assert any(
+            m["role"] == "system" and "maximum tool-call-round budget has been reached" in m["content"].lower()
+            for m in finalize_msgs
+        )
+
+    def test_failed_finalization_falls_back_to_error_with_meta(self, app, agent, monkeypatch):
+        agent.max_tool_rounds = 2
+        counter = {"n": 0}
+
+        def fake_stream(agent_, messages, tools):
+            if tools is None:
+                raise RuntimeError("model down")
+            counter["n"] += 1
+            yield ("tool_calls", [{
+                "id": f"c{counter['n']}",
+                "function": {"name": "noop", "arguments": json.dumps({"n": counter["n"]})},
+            }])
+
+        monkeypatch.setattr(agent_runner, "build_context", lambda a, s, m: [{"role": "user", "content": m}])
+        monkeypatch.setattr(agent_runner, "stream_chat_completion", fake_stream)
+        monkeypatch.setattr(agent_runner, "execute_tool", lambda *a, **k: {"ok": True})
+        monkeypatch.setattr("app.services.agent_budget_service.check_budget", lambda a: None)
+        monkeypatch.setattr("app.workspace.discovery.get_agent_tool_definitions",
+                            lambda a: [{"type": "function", "function": {"name": "noop", "parameters": {}}}])
+        monkeypatch.setattr("app.runtime.context_budget.model_context_window", lambda *a, **k: 1_000_000)
+        monkeypatch.setattr("app.runtime.context_budget.effective_budget", lambda *a, **k: 1_000_000)
+        monkeypatch.setattr("app.runtime.tool_registry.forget_run_reads", lambda run_id: None)
+
+        chunks = [json.loads(c) for c in agent_runner.run(agent, None, "go", run_id=2)]
+        final = chunks[-1]
+        assert final["type"] == "error"
+        assert final["data"] == "Maximum tool call rounds reached"
+        assert final["meta"]["termination_reason"] == "max_tool_rounds"
+
+
+class TestResolveOutcome:
+    def test_error_takes_precedence(self):
+        assert _resolve_outcome("boom", {"termination_reason": "max_tool_rounds"}) == ("error", "boom")
+
+    def test_partial_from_meta(self):
+        status, note = _resolve_outcome(None, {
+            "termination_reason": "max_tool_rounds",
+            "tool_round_limit": 20,
+            "tool_executions_count": 7,
+            "last_tool_name": "get_credential",
+            "last_tool_status": "ok",
+        })
+        assert status == "partial"
+        assert "20" in note and "7" in note
+
+    def test_plain_completion(self):
+        assert _resolve_outcome(None, None) == ("completed", None)


### PR DESCRIPTION
Fixes #25.

Runs that hit the tool-call-round cap aborted with a bare `Maximum tool call rounds reached`, silently losing the task.

This change:
- warns the model once when <=2 rounds remain;
- performs a final no-tool turn that synthesizes a partial answer instead of hard-aborting;
- emits structured termination metadata and records the run as a new `partial` status (amber badge + log filter);
- adds a regression test.

Secret redaction in run logs (also raised in #25) is intentionally left as a separate security follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)