### PR TITLE
fix(scheduler): correct cron day-of-week off-by-one in worker

### DIFF
--- a/app/worker/cron_compat.py
+++ b/app/worker/cron_compat.py
@@ -1,0 +1,85 @@
+"""Bridge standard crontab day-of-week semantics onto APScheduler.
+
+APScheduler's ``CronTrigger`` numbers the day-of-week field ``0=Monday ..
+6=Sunday`` and rejects ``7``. Standard crontab (and ``croniter``, which we use
+for ``compute_next_run``) numbers it ``0=Sunday .. 6=Saturday`` with ``7`` also
+meaning Sunday. ``CronTrigger.from_crontab`` does *not* reconcile the two, so a
+cron string like ``0 14 * * 5`` (Friday) was scheduled for Saturday and ``* * 7``
+crashed (issue #27).
+
+This module rewrites only the DOW field — every other field shares the same
+convention — so the worker fires on the weekday the cron string actually means
+and stays consistent with ``scheduler_service.compute_next_run``.
+"""
+
+from apscheduler.triggers.cron import CronTrigger
+
+# cron day number (0=Sun..6=Sat) -> APScheduler day number (0=Mon..6=Sun).
+_CRON_TO_APS = {0: 6, 1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5}
+
+
+def _expand_token(token):
+    """Expand one DOW token into a set of cron day ints (0..6, 7 -> 0)."""
+    token = token.strip()
+    step = 1
+    base = token
+    if "/" in token:
+        base, step_str = token.split("/", 1)
+        step = int(step_str)
+
+    base = base.strip()
+    if base == "*":
+        lo, hi = 0, 7
+    elif "-" in base:
+        lo_str, hi_str = base.split("-", 1)
+        lo, hi = int(lo_str), int(hi_str)
+    else:
+        return {int(base) % 7}  # single value; 7 normalizes to Sunday (0)
+
+    return {x % 7 for x in range(lo, hi + 1, step)}
+
+
+def cron_dow_to_apscheduler(field):
+    """Translate a standard cron DOW field to APScheduler's day_of_week field.
+
+    ``*`` passes through, alphabetic fields (``mon``, ``mon-fri``) pass through
+    unchanged because APScheduler already interprets weekday *names* correctly.
+    Numeric tokens — singles, lists, ranges and steps — are expanded and remapped
+    to APScheduler's Monday-based numbering, emitted as a plain comma list so
+    boundary cases (Sunday, ``7``) never form an invalid wrapped range.
+    """
+    field = field.strip()
+    if field in ("*", "?"):
+        return "*"
+    if any(c.isalpha() for c in field):
+        return field
+
+    cron_days = set()
+    for tok in field.split(","):
+        if tok.strip() == "*":
+            return "*"
+        cron_days |= _expand_token(tok)
+
+    aps_days = sorted(_CRON_TO_APS[d] for d in cron_days)
+    return ",".join(str(d) for d in aps_days)
+
+
+def build_cron_trigger(expr, timezone="UTC"):
+    """Build a ``CronTrigger`` from a 5-field cron string with correct DOW.
+
+    Falls back to APScheduler's own parser for non 5-field inputs (e.g. the
+    ``@hourly`` shortcuts), which don't carry an ambiguous numeric DOW field.
+    """
+    parts = expr.split()
+    if len(parts) != 5:
+        return CronTrigger.from_crontab(expr, timezone=timezone)
+
+    minute, hour, dom, month, dow = parts
+    return CronTrigger(
+        minute=minute,
+        hour=hour,
+        day=dom,
+        month=month,
+        day_of_week=cron_dow_to_apscheduler(dow),
+        timezone=timezone,
+    )

--- a/app/worker/scheduler.py
+++ b/app/worker/scheduler.py
@@ -2,8 +2,9 @@ import logging
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
+
+from app.worker.cron_compat import build_cron_trigger
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ def _sync_jobs(app):
                                 "Unknown timezone %r for task %s; falling back to UTC",
                                 task.timezone, task.id,
                             )
-                    trigger = CronTrigger.from_crontab(task.schedule_expr, timezone=tz_name)
+                    trigger = build_cron_trigger(task.schedule_expr, timezone=tz_name)
                     _ensure_job(
                         job_id=job_id,
                         func=_execute_cron_task,

--- a/tests/test_cron_compat.py
+++ b/tests/test_cron_compat.py
@@ -1,0 +1,101 @@
+"""Regression tests for cron day-of-week handling in the worker (issue #27).
+
+APScheduler numbers DOW Monday-based and rejects 7; standard cron is
+Sunday-based with 7 == Sunday. ``cron_compat`` reconciles the two so the worker
+fires weekly tasks on the weekday the cron string actually means, matching
+``scheduler_service.compute_next_run`` (croniter).
+"""
+
+from datetime import datetime
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from app.worker.cron_compat import build_cron_trigger, cron_dow_to_apscheduler
+
+TZ = "Europe/Madrid"
+# 2026-06-14 is a Sunday; start the search just after midnight local.
+_BASE = datetime(2026, 6, 14, 0, 30, tzinfo=ZoneInfo(TZ))
+
+_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+
+def _next_weekday(expr):
+    trig = build_cron_trigger(expr, timezone=TZ)
+    nf = trig.get_next_fire_time(None, _BASE)
+    assert nf is not None, f"{expr} produced no fire time"
+    return _NAMES[nf.weekday()]
+
+
+class TestSingleDow:
+    @pytest.mark.parametrize("dow,expected", [
+        (0, "Sun"),
+        (1, "Mon"),
+        (2, "Tue"),
+        (3, "Wed"),
+        (4, "Thu"),
+        (5, "Fri"),
+        (6, "Sat"),
+        (7, "Sun"),  # 7 must not crash and must mean Sunday
+    ])
+    def test_dow_maps_to_correct_weekday(self, dow, expected):
+        assert _next_weekday(f"0 14 * * {dow}") == expected
+
+    def test_friday_is_not_saturday(self):
+        # The exact symptom from the issue.
+        assert _next_weekday("0 14 * * 5") == "Fri"
+
+    def test_saturday_is_not_sunday(self):
+        assert _next_weekday("0 9 * * 6") == "Sat"
+
+
+class TestRangesAndLists:
+    def test_weekday_range_1_5(self):
+        # mon-fri: first fire after Sunday base is Monday.
+        assert _next_weekday("0 14 * * 1-5") == "Mon"
+
+    def test_list_with_sunday(self):
+        assert cron_dow_to_apscheduler("0,1,2,3,4") == "0,1,2,3,6"
+
+    def test_weekend_list_5_6(self):
+        # Fri(->4), Sat(->5)
+        assert cron_dow_to_apscheduler("5,6") == "4,5"
+
+    def test_range_1_5_field(self):
+        assert cron_dow_to_apscheduler("1-5") == "0,1,2,3,4"
+
+    def test_star_passthrough(self):
+        assert cron_dow_to_apscheduler("*") == "*"
+
+    def test_name_passthrough(self):
+        # APScheduler already maps weekday names correctly.
+        assert cron_dow_to_apscheduler("mon-fri") == "mon-fri"
+
+    def test_step_every_two_days(self):
+        # cron */2 over Sun..Sat -> Sun,Tue,Thu,Sat (0,2,4,6) -> aps 6,1,3,5
+        assert cron_dow_to_apscheduler("*/2") == "1,3,5,6"
+
+
+class TestConsistencyWithCroniter:
+    """The worker trigger must agree with compute_next_run for every DOW."""
+
+    @pytest.mark.parametrize("dow", list(range(8)))
+    def test_trigger_matches_croniter(self, dow):
+        from app.services.scheduler_service import compute_next_run
+
+        expr = f"0 14 * * {dow}"
+        croniter_next = compute_next_run(expr, base_time=_BASE, tz_name=TZ)
+        trigger_next = build_cron_trigger(expr, timezone=TZ).get_next_fire_time(None, _BASE)
+
+        assert croniter_next.weekday() == trigger_next.weekday(), (
+            f"dow={dow}: croniter={croniter_next} trigger={trigger_next}"
+        )
+
+
+class TestNonStandardExpr:
+    def test_non_five_field_delegates_to_apscheduler(self):
+        # Not a 5-field expr: we delegate to APScheduler, which (like before this
+        # fix) only accepts 5-field crontab and rejects shortcuts. The worker
+        # catches this ValueError and logs the task as having an invalid cron.
+        with pytest.raises(ValueError):
+            build_cron_trigger("@hourly", timezone=TZ)


### PR DESCRIPTION
Fixes #27.

Weekly cron tasks fired one weekday late (`0 14 * * 5` → Saturday instead of Friday) and `* * 7` crashed. Root cause: APScheduler `CronTrigger.from_crontab` numbers day-of-week Monday-based (0=Mon..6=Sun, no 7) while standard cron / croniter are Sunday-based (0=Sun..6=Sat, 7=Sun). The worker also wrote the wrong fire time back into `next_run_at`.

New `app/worker/cron_compat.build_cron_trigger()` remaps only the DOW field to APScheduler convention; the worker uses it instead of `from_crontab`. Existing enabled tasks self-heal on the next `_sync_jobs` pass — no migration.

Tests cover DOW 0-7, lists/ranges, and trigger↔croniter consistency.

Operational follow-up on the live instance (not code): cancel diagnostic task 33, reactivate weekly tasks 19-22 after verifying next-run dates, leave task 23 disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)