### PR TITLE
Fix run_bash to preserve workspace venv PATH

### DIFF
--- a/app/runtime/tool_registry/bash_tools.py
+++ b/app/runtime/tool_registry/bash_tools.py
@@ -15,7 +15,7 @@ def register_bash_tools():
                 "(optionally a subdirectory via `workdir`). The agent's per-workspace "
                 "venv, if one exists, is prepended to PATH so packages installed through "
                 "`install_package` are importable. Provide EITHER `command` (one-liner "
-                "evaluated with `bash -lc`) OR `script` (multi-line bash body, wrapped "
+                "evaluated with `bash -c`) OR `script` (multi-line bash body, wrapped "
                 "with `set -euo pipefail`). Output is truncated to ~20k characters."
             ),
             parameters={
@@ -52,6 +52,11 @@ def _run_bash(_agent=None, _run_id=None, command=None, script=None,
     has cwd pinned inside ``workspace_path``. We also prepend the per-workspace
     venv's bin dir to PATH when present so the agent can call packages it
     installed via ``install_package`` without activating the venv by hand.
+
+    One-line commands intentionally use ``bash -c`` instead of ``bash -lc``.
+    A login shell may reinitialize PATH from profile files and drop the venv
+    prefix, which makes ``python`` resolve to the system interpreter even when
+    ``venv_active`` is true.
     """
     import os
     import subprocess
@@ -118,7 +123,7 @@ def _run_bash(_agent=None, _run_id=None, command=None, script=None,
             os.chmod(temp_path, 0o700)
             argv = ["bash", temp_path]
         else:
-            argv = ["bash", "-lc", command]
+            argv = ["bash", "-c", command]
 
         proc = subprocess.run(
             argv,

--- a/tests/test_run_bash_venv_path.py
+++ b/tests/test_run_bash_venv_path.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.runtime.tool_registry.bash_tools import _run_bash
+
+
+def _make_fake_workspace(tmp_path: Path) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    venv_bin = workspace / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    python = venv_bin / "python"
+    python.write_text("#!/usr/bin/env sh\necho venv-python\n", encoding="utf-8")
+    python.chmod(0o755)
+    return workspace, venv_bin
+
+
+def test_run_bash_command_resolves_workspace_venv_python_first(tmp_path):
+    workspace, venv_bin = _make_fake_workspace(tmp_path)
+    agent = SimpleNamespace(workspace_path=str(workspace))
+
+    result = _run_bash(
+        _agent=agent,
+        command="printf '%s\n' \"$(command -v python)\"; python",
+    )
+
+    assert result["ok"] is True
+    assert result["venv_active"] is True
+    lines = result["stdout"].splitlines()
+    assert lines[0] == str(venv_bin / "python")
+    assert lines[1] == "venv-python"
+
+
+def test_run_bash_command_exports_virtual_env(tmp_path):
+    workspace, _venv_bin = _make_fake_workspace(tmp_path)
+    agent = SimpleNamespace(workspace_path=str(workspace))
+
+    result = _run_bash(_agent=agent, command="printf '%s' \"$VIRTUAL_ENV\"")
+
+    assert result["ok"] is True
+    assert result["stdout"] == str(workspace / ".venv")
+
+
+def test_run_bash_command_uses_non_login_shell(monkeypatch, tmp_path):
+    workspace, venv_bin = _make_fake_workspace(tmp_path)
+    agent = SimpleNamespace(workspace_path=str(workspace))
+    captured = {}
+
+    class Proc:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(argv, cwd, env, capture_output, text, timeout):
+        captured["argv"] = argv
+        captured["env"] = env
+        return Proc()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = _run_bash(_agent=agent, command="echo ok")
+
+    assert result["ok"] is True
+    assert captured["argv"] == ["bash", "-c", "echo ok"]
+    assert captured["env"]["PATH"].split(os.pathsep)[0] == str(venv_bin)
+
+
+def test_run_bash_script_receives_workspace_venv_path(tmp_path):
+    workspace, venv_bin = _make_fake_workspace(tmp_path)
+    agent = SimpleNamespace(workspace_path=str(workspace))
+
+    result = _run_bash(
+        _agent=agent,
+        script="printf '%s\n' \"$(command -v python)\"\npython\n",
+    )
+
+    assert result["ok"] is True
+    lines = result["stdout"].splitlines()
+    assert lines[0] == str(venv_bin / "python")
+    assert lines[1] == "venv-python"


### PR DESCRIPTION
## Summary

Fixes a regression where `run_bash` reported `venv_active: true` but `python` inside the shell could still resolve to the system interpreter instead of the agent workspace venv interpreter.

## Problem observed

During an agent self-check, the package inventory showed packages installed in the workspace venv (`<workspace>/.venv`), but a plain `python` run through `run_bash` resolved to `/usr/local/bin/python`. As a result, imports such as `feedparser`, `whisper`, `yt_dlp`, `smbprotocol`, and `pysnmp` appeared missing even though they were installed and worked when invoked explicitly with `./.venv/bin/python`.

Root cause: `run_bash` prepended `<workspace>/.venv/bin` to `PATH`, but one-line commands were executed as `bash -lc`. The login shell path initialization can override the inherited `PATH`, causing the venv prefix to be lost.

## Changes

- Execute one-line `run_bash` commands with `bash -c` instead of `bash -lc`.
- Keep scripts unchanged, still executed through a temporary bash script.
- Update the tool description to say commands are evaluated with `bash -c`.
- Add regression tests that verify:
  - the venv Python is resolved first in `PATH`;
  - `VIRTUAL_ENV` is exported;
  - one-line commands no longer use login-shell mode;
  - script execution still receives the venv PATH.

## Why this matters

New installations and future agents should be able to trust that packages installed via `install_package` are importable from `run_bash` using normal commands like `python -c ...`, without requiring manual `./.venv/bin/python` workarounds.

## Validation

Added pytest coverage for the environment and argv behavior in `run_bash`.